### PR TITLE
Increment erased block count in erase loop

### DIFF
--- a/DataFlashBlockDevice.cpp
+++ b/DataFlashBlockDevice.cpp
@@ -413,7 +413,7 @@ int DataFlashBlockDevice::erase(bd_addr_t addr, bd_size_t size)
 
             /* update loop variables */
             addr += _block_size;
-            erased -= _block_size;
+            erased += _block_size;
         }
 
         /* enable write protection */


### PR DESCRIPTION
Erase() only erases one block. It looks like "erased" variable is erroneously decremented instead of increment. Underflows at first loop iteration.

#6 