### PR TITLE
Enable DATAFLASH_DEBUG to be defined externally

### DIFF
--- a/DataFlashBlockDevice.cpp
+++ b/DataFlashBlockDevice.cpp
@@ -36,7 +36,9 @@
 #define DATAFLASH_PAGE_BIT_528     10
 
 /* enable debug */
+#ifndef DATAFLASH_DEBUG
 #define DATAFLASH_DEBUG 0
+#endif /* DATAFLASH_DEBUG */
 
 #if DATAFLASH_DEBUG
 #define DEBUG_PRINTF(...) printf(__VA_ARGS__)


### PR DESCRIPTION
(for example in a Makefile) instead of it being hardcoded in the .cpp file.