### PR TITLE
Implement the get_erase_size API (based on address)

### DIFF
--- a/DataFlashBlockDevice.cpp
+++ b/DataFlashBlockDevice.cpp
@@ -446,6 +446,13 @@ bd_size_t DataFlashBlockDevice::get_erase_size() const
     return _block_size;
 }
 
+bd_size_t DataFlashBlockDevice::get_erase_size(bd_addr_t addr) const
+{
+    DEBUG_PRINTF("erase size: %" PRIX16 "\r\n", _block_size);
+
+    return _block_size;
+}
+
 bd_size_t DataFlashBlockDevice::size() const
 {
     DEBUG_PRINTF("device size: %" PRIX32 "\r\n", _device_size);

--- a/DataFlashBlockDevice.h
+++ b/DataFlashBlockDevice.h
@@ -139,6 +139,14 @@ public:
      */
     virtual bd_size_t get_erase_size() const;
 
+    /** Get the size of an erasable block given address
+     *
+     *  @param addr     Address within the erasable block
+     *  @return         Size of an erasable block in bytes
+     *  @note Must be a multiple of the program size
+     */
+    virtual bd_size_t get_erase_size(bd_addr_t addr) const;
+
     /** Get the total size of the underlying device
      *
      *  @return         Size of the underlying device in bytes


### PR DESCRIPTION
Description:
Implemented the `get_erase_size(bd_addr_t addr)` API (one depending on address).
Fixes the warning described in issue [#35](https://github.com/ARMmbed/storage-selector/issues/35) of storage_selector repo.