### PR TITLE
Adding deprecation warning for mbed-os 5.10

### DIFF
--- a/DataFlashBlockDevice.cpp
+++ b/DataFlashBlockDevice.cpp
@@ -19,6 +19,12 @@
 
 #include <inttypes.h>
 
+/* Started from version 5.10.0 DataFlashBlockDevice external repo is depricated. 
+   please use the DataFlashBlockDevice component inside mbed-os.*/
+#if defined(MBED_MAJOR_VERSION) && MBED_MAJOR_VERSION >= 5 && (MBED_VERSION >= MBED_ENCODE_VERSION(5,10,0))
+#error "Started from version 5.10.0 DataFlashBlockDevice external repo is depricated. please use the DataFlashBlockDevice component inside mbed-os."
+#endif
+
 /* constants */
 #define DATAFLASH_READ_SIZE        1
 #define DATAFLASH_PROG_SIZE        1

--- a/DataFlashBlockDevice.cpp
+++ b/DataFlashBlockDevice.cpp
@@ -19,10 +19,10 @@
 
 #include <inttypes.h>
 
-/* Started from version 5.10.0 DataFlashBlockDevice external repo is depricated. 
+/* Started from version 5.10.0 DataFlashBlockDevice external repo is deprecated. 
    please use the DataFlashBlockDevice component inside mbed-os.*/
 #if defined(MBED_MAJOR_VERSION) && MBED_MAJOR_VERSION >= 5 && (MBED_VERSION >= MBED_ENCODE_VERSION(5,10,0))
-#error "Started from version 5.10.0 DataFlashBlockDevice external repo is depricated. please use the DataFlashBlockDevice component inside mbed-os."
+#error "Started from version 5.10.0 DataFlashBlockDevice external repo is deprecated. please use the DataFlashBlockDevice component inside mbed-os."
 #endif
 
 /* constants */

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+# Warning
+Starting from mbed-os 5.10 this repository is deprecated. 
+Please refer to mbed-os 5.10 documentation for more detail on how to enable DATAFLASH support.
+
 # DataFlash Driver
 
 Block device driver for I2C based EEPROM devices such as the Adesto AT45DB

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Warning
 Starting from mbed-os 5.10 this repository is deprecated. 
-Please refer to mbed-os 5.10 documentation for more detail on how to enable DATAFLASH support.
+Please refer to mbed-os 5.10 [documentation](https://github.com/ARMmbed/mbed-os-5-docs/blob/development/docs/api/storage/DataFlashBlockDevice.md) and [code](https://github.com/ARMmbed/mbed-os/tree/master/components/storage/blockdevice/COMPONENT_DATAFLASH) for more detail on how to enable DATAFLASH support.
 
 # DataFlash Driver
 


### PR DESCRIPTION
Starting mbed-os 5.10 the SD driver has moved into mbed-os.
Therefore this PR is adding a warning in the DATAFLASH documentation for the incoming depreciation. 

This PR is dependent on PR #7774
https://github.com/ARMmbed/mbed-os/pull/7774
